### PR TITLE
(MERGE FIRST) Fix check on CI: Use stringsAsFactors = FALSE

### DIFF
--- a/R/imports.R
+++ b/R/imports.R
@@ -1,6 +1,12 @@
 #' @importFrom utils data
 NULL
 
+# FIXME: Hack to use stringsAsFactors = FALSE everywhere, with all versions of R
+# Can we use tibble() instead? (We are using dplyr, and it exports tibble().)
+data.frame <- function(...) {
+  base::data.frame(..., stringsAsFactors = FALSE)
+}
+
 globalVariables(
   c(
     "Lat",

--- a/R/resample_agb.R
+++ b/R/resample_agb.R
@@ -108,7 +108,6 @@ resample_agb <- function(genus,
 
   df <- data.frame(equation_id,
                    dbh = unlist(list_dbh),
-                   agb = unlist(list_agb),
-                   stringsAsFactors = FALSE)
+                   agb = unlist(list_agb))
   return(df)
 }

--- a/R/resample_agb.R
+++ b/R/resample_agb.R
@@ -108,6 +108,7 @@ resample_agb <- function(genus,
 
   df <- data.frame(equation_id,
                    dbh = unlist(list_dbh),
-                   agb = unlist(list_agb))
+                   agb = unlist(list_agb),
+                   stringsAsFactors = FALSE)
   return(df)
 }


### PR DESCRIPTION
MERGE this PR first so that the checks pass for all other open PRs.

---

Fixes this error, which surfaces only in some platforms:

-- Failure (test-resample_agb.R:12:3): resample_agb returns a dataframe of size 1e6 x 3 --
res_test$equation_id inherits from `factor` not `character`.

https://github.com/forestgeo/allodb/pull/124/checks?check_run_id=1893660473
