### PR TITLE
Remove needless dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,11 +28,8 @@ Depends:
     R (>= 3.5.0)
 Imports: 
     data.table (>= 1.12.8),
-    dplyr (>= 0.8.0.1),
     ggplot2 (>= 3.3.2),
     kgc (>= 1.0.0.2),
-    raster,
-    readr (>= 1.3.1),
     utils
 Suggests: 
     covr (>= 3.2.1),
@@ -40,13 +37,12 @@ Suggests:
     purrr,
     rmarkdown,
     spelling,
-    testthat (>= 3.0.0),
-    rmarkdown
+    testthat (>= 3.0.0)
 VignetteBuilder: 
     knitr
+Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
-Config/testthat/edition: 3


### PR DESCRIPTION
Address this:

```
✖ fix this R CMD check NOTE: Namespaces in
Imports field not imported from: 'dplyr' 'raster'
'readr' All declared Imports should be used.
```