### PR TITLE
Flag FIXME in resample_agb()

### DIFF
--- a/R/resample_agb.R
+++ b/R/resample_agb.R
@@ -93,6 +93,15 @@ resample_agb <- function(genus,
     list_agb <-
       eval(parse(text = new_equation)) * dfsub$output_units_cf
   } else {
+    # FIXME: The iteration in this 'else' branch appears to be wrong, likely
+    # because lapply() syntax is mixed with for() syntax. Operations over all
+    # items in a vector appear to be mixed with operations over a single element
+    # of a vector. The result is that the length of `list_dbh` is different from
+    # the length of `list_agb`. Please revise this chunk and write a test to
+    # ensure the result is what you expect and to avoid this bug from comming
+    # back in the future. As an intermediate step to fix this bug it may be
+    # easiest to extract the logic of this chunk in a little helper function
+    # then test that helper in isolation.
     list_agb <- lapply(seq_len(length(list_dbh)), function(j) {
       sampled_dbh <- list_dbh[[j]]
       orig_equation <- dfsub$equation_allometry[j]


### PR DESCRIPTION
Please see the comment I flag with FIXME. 

The chunk I flag was mainly written by @cpiponiot, so she may be the best person to revise its logic. @gonzalezb edited line 108 to incorporate my suggestion, but once `sampled_dbh` was actually used the bug was exposed.

```bash
...
244fd3d4d (Camille Piponiot    2021-01-26 18:38:24 +0100 105)     list_agb <- lapply(seq_len(length(list_dbh)), function(j) {
9a0b2493c (Camille Piponiot    2021-01-05 16:54:12 +0100 106)       sampled_dbh <- list_dbh[[j]]
9a0b2493c (Camille Piponiot    2021-01-05 16:54:12 +0100 107)       orig_equation <- dfsub$equation_allometry[j]
62f30be9b (Erika Gonzalez-Akre 2021-04-13 22:37:53 -0400 108)       new_dbh <- paste0("(", sampled_dbh, "*", dfsub$dbh_unit_cf[j], ")")
9a0b2493c (Camille Piponiot    2021-01-05 16:54:12 +0100 109)       new_equation <- gsub("dbh|DBH", new_dbh, orig_equation)
70cc898cc (Camille Piponiot    2021-01-26 17:35:19 +0100 110)       agb <-
1d932d96c (Camille Piponiot    2021-03-24 10:30:32 +0100 111)         eval(parse(text = new_equation)) * dfsub$output_units_cf[j]
9a0b2493c (Camille Piponiot    2021-01-05 16:54:12 +0100 112)     })
9a0b2493c (Camille Piponiot    2021-01-05 16:54:12 +0100 113)   }
...﻿
```

Let me know if you need help. We could do a peer-programming session to try come up with a robust implementation that does what we want.

