### PR TITLE
Remove str2lang in favor of parse(text = )

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,6 +32,7 @@ jobs:
           - {os: ubuntu-18.04,   r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", http-user-agent: "R/4.1.0 (ubuntu-18.04) R (4.1.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }
           - {os: ubuntu-18.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
           - {os: ubuntu-18.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
+          - {os: ubuntu-18.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
 
     env:
       RSPM: ${{ matrix.config.rspm }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ License: GPL-3
 URL: https://forestgeo.github.io/allodb, https://github.com/forestgeo/allodb
 BugReports: https://github.com/forestgeo/allodb/issues
 Depends: 
-    R (>= 3.6.0)
+    R (>= 3.5.0)
 Imports: 
     data.table (>= 1.12.8),
     ggplot2 (>= 3.3.2),

--- a/R/resample_agb.R
+++ b/R/resample_agb.R
@@ -98,7 +98,7 @@ resample_agb <- function(genus,
       new_dbh <- paste0("(sampled_dbh * ", dfsub$dbh_unit_cf[j], ")")
       new_equation <- gsub("dbh|DBH", new_dbh, orig_equation)
       agb <-
-        eval(str2lang(new_equation)) * dfsub$output_units_cf[j]
+        eval(parse(text = new_equation)) * dfsub$output_units_cf[j]
     })
   }
 


### PR DESCRIPTION
str2lang() seems to not avoid any of the issues that 
parse(text = ) has, so I prefer to remove it so we
can again support R >= 3.5 rather than R >= 3.6.

Also, in #151 we argue that the issues of parse(text = )
may be balanced out by their benefits.

 
